### PR TITLE
[TASK] Add possibility to use CLOUDSDK_PYTHON var on linux

### DIFF
--- a/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
+++ b/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
@@ -98,6 +98,13 @@ public abstract class AbstractGcloudMojo extends AbstractMojo {
         pythonLocation = "python.exe";
       }
     }
+
+    String possibleLinuxPythonLocation = System.getenv("CLOUDSDK_PYTHON");
+    if (possibleLinuxPythonLocation != null) {
+      getLog().info("Found a python interpreter specified via CLOUDSDK_PYTHON at: " + possibleLinuxPythonLocation);
+      pythonLocation = possibleLinuxPythonLocation;
+    }
+
     commands.add(pythonLocation);
     commands.add("-S");
 

--- a/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
+++ b/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
@@ -97,12 +97,12 @@ public abstract class AbstractGcloudMojo extends AbstractMojo {
 
         pythonLocation = "python.exe";
       }
-    }
-
-    String possibleLinuxPythonLocation = System.getenv("CLOUDSDK_PYTHON");
-    if (possibleLinuxPythonLocation != null) {
-      getLog().info("Found a python interpreter specified via CLOUDSDK_PYTHON at: " + possibleLinuxPythonLocation);
-      pythonLocation = possibleLinuxPythonLocation;
+    } else {
+      String possibleLinuxPythonLocation = System.getenv("CLOUDSDK_PYTHON");
+      if (possibleLinuxPythonLocation != null) {
+        getLog().info("Found a python interpreter specified via CLOUDSDK_PYTHON at: " + possibleLinuxPythonLocation);
+        pythonLocation = possibleLinuxPythonLocation;
+      }
     }
 
     commands.add(pythonLocation);


### PR DESCRIPTION
Until now, the environment variable for an alternative python interpreter ist only used on windows boxes.

This patch applies a similar condition to check for it even when no windows is present.