### PR TITLE
Check if python uses sites module or virtual_env before disabling import of 'sites'.

### DIFF
--- a/src/main/java/com/google/appengine/Utils.java
+++ b/src/main/java/com/google/appengine/Utils.java
@@ -58,5 +58,18 @@ public class Utils {
     }
     return gcloudDir;
   }
+  
+  public static boolean canDisableImportOfPythonModuleSite() {
+    // If either CLOUDSDK_PYTHON_SITEPACKAGES or VIRTUAL_ENV is defined
+    // we shall NOT disable import of module 'site'.
+    String sitePackages = System.getenv("CLOUDSDK_PYTHON_SITEPACKAGES");
+    String virtualEnv = System.getenv("VIRTUAL_ENV");
+    boolean noSiteDefined = sitePackages == null || sitePackages.isEmpty();
+    boolean noVirtEnvDefined = virtualEnv == null || virtualEnv.isEmpty();
+    if (noSiteDefined && noVirtEnvDefined) {
+      return true;
+    }
+    return false;
+  }
 
 }

--- a/src/main/java/com/google/appengine/Utils.java
+++ b/src/main/java/com/google/appengine/Utils.java
@@ -59,9 +59,15 @@ public class Utils {
     return gcloudDir;
   }
   
+  /**
+   * Checks if either CLOUDSDK_PYTHON_SITEPACKAGES or VIRTUAL_ENV is defined.
+   * 
+   * <p> If either variable is defined, we shall not disable import of module
+   * 'site.
+   * 
+   * @return true if it is OK to disable import of module 'site' (python -S)  
+   */
   public static boolean canDisableImportOfPythonModuleSite() {
-    // If either CLOUDSDK_PYTHON_SITEPACKAGES or VIRTUAL_ENV is defined
-    // we shall NOT disable import of module 'site'.
     String sitePackages = System.getenv("CLOUDSDK_PYTHON_SITEPACKAGES");
     String virtualEnv = System.getenv("VIRTUAL_ENV");
     boolean noSiteDefined = sitePackages == null || sitePackages.isEmpty();

--- a/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
+++ b/src/main/java/com/google/appengine/gcloudapp/AbstractGcloudMojo.java
@@ -144,7 +144,9 @@ public abstract class AbstractGcloudMojo extends AbstractMojo {
     String pythonLocation = Utils.getPythonExecutableLocation();
 
     commands.add(pythonLocation);
-    commands.add("-S");
+    if (Utils.canDisableImportOfPythonModuleSite()) {
+      commands.add("-S");
+    }
 
     if (gcloud_directory == null) {
       gcloud_directory = Utils.getCloudSDKLocation();
@@ -602,7 +604,9 @@ public abstract class AbstractGcloudMojo extends AbstractMojo {
   private void installJavaAppEngineComponent(String pythonLocation ) throws MojoExecutionException {
     ArrayList<String> installCommand = new ArrayList<>();
     installCommand.add(pythonLocation);
-    installCommand.add("-S");
+    if (Utils.canDisableImportOfPythonModuleSite()) {
+      installCommand.add("-S");
+    }
     installCommand.add(gcloud_directory + "/lib/googlecloudsdk/gcloud/gcloud.py");
     installCommand.add("components");
     installCommand.add("update");


### PR DESCRIPTION
gcloud SDK checks for the existence of two variables:
CLOUDSDK_PYTHON_SITEPACKAGES
VIRTUAL_ENV

If none of these variable are defined, then the sdk adds "-S" to python interpreter so that the 'sites' module is disabled (which apparently speeds things up). Otherwise, "-S" is not used. 

In the maven plugin, though, we were adding "-S" in any case. This pull request includes a change to check for the two environment variables.