### PR TITLE
Add ansible playbook for setting up e2e test

### DIFF
--- a/e2e/create_vm.sh
+++ b/e2e/create_vm.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# TODO: change this to local ansible task (see google cloud compute module)
+gcloud compute --project "maven-end-to-end" \
+instances create "deploy-vm" \
+--zone "us-central1-f" \
+--machine-type "n1-standard-1" \
+--network "default" \
+--maintenance-policy "MIGRATE" \
+--scopes "https://www.googleapis.com/auth/cloud-platform,\
+https://www.googleapis.com/auth/userinfo.email,\
+https://www.googleapis.com/auth/compute,\
+https://www.googleapis.com/auth/devstorage.full_control,\
+https://www.googleapis.com/auth/logging.write,\
+https://www.googleapis.com/auth/cloud-platform,\
+https://www.googleapis.com/auth/appengine.admin" \
+--image "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1504-vivid-v20150616a" \
+--boot-disk-type "pd-standard" \
+--boot-disk-device-name "deploy-vm"

--- a/e2e/group_vars/compute
+++ b/e2e/group_vars/compute
@@ -1,0 +1,2 @@
+java_home: /usr/lib/jvm/java-7-openjdk-amd64
+maven_home: /opt/apache-maven-3.3.3

--- a/e2e/hosts
+++ b/e2e/hosts
@@ -1,7 +1,4 @@
-[local]
-localhost
-
 [compute]
-104.197.110.30 ansible_ssh_private_key_file=/Users/ifigotin/.ssh/google_compute_engine
+host ansible_ssh_private_key_file=path_to_google_compute_engine
 
 

--- a/e2e/hosts
+++ b/e2e/hosts
@@ -1,0 +1,7 @@
+[local]
+localhost
+
+[compute]
+104.197.110.30 ansible_ssh_private_key_file=/Users/ifigotin/.ssh/google_compute_engine
+
+

--- a/e2e/roles/common/tasks/main.yml
+++ b/e2e/roles/common/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: Install required packages
+  apt: name={{ item }} state=installed update_cache=yes
+  with_items:
+        - openjdk-7-jdk
+        - unzip
+        - curl
+        - git
+        - expect
+        - bsh
+  sudo: yes

--- a/e2e/roles/common/tasks/main.yml.bkp
+++ b/e2e/roles/common/tasks/main.yml.bkp
@@ -1,0 +1,124 @@
+---
+
+- name: Install required packages
+  apt: name={{ item }} state=installed update_cache=yes
+  with_items:
+        - openjdk-7-jdk
+        - unzip
+        - curl
+        - git
+        - expect
+        - bsh
+  sudo: yes
+
+- name: Install openjdk-7-jdk
+  apt: name=openjdk-7-jdk state=present update_cache=yes
+  sudo: yes
+
+- name: Install unzip
+  apt: name=unzip state=present
+  sudo: yes
+
+- name: Install curl
+  apt: name=curl state=present
+  sudo: yes
+
+- name: Install git
+  apt: name=git state=present
+  sudo: yes
+
+- name: Remove gcloud installation
+  file: path=/usr/lib/google-cloud-sdk state=absent
+  sudo: yes
+
+- name: Remove gcloud
+  file: path=/usr/bin/gcloud state=absent
+  sudo: yes
+
+#- name: Remove gcloud .config
+#  file: path=~/.config state=absent
+
+- name: Download maven 3
+  get_url:
+        url: http://mirror.metrocast.net/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.zip
+        dest: /tmp/apache-maven-3.3.3-bin.zip
+  sudo: yes
+
+- name: Create maven dir
+  file: path=/opt/apache-maven-3.3.3 state=directory mode=0755
+  sudo: yes
+
+- name: Unzip maven
+  unarchive: src=/tmp/apache-maven-3.3.3-bin.zip dest=/opt copy=no mode=0755
+  sudo: yes
+
+- name: Install maven_env.sh
+  template: src=maven_env.sh dest=/etc/profile.d/maven_env.sh mode=0644
+  sudo: yes
+
+- name: Maven version
+  command: "{{maven_home}}/bin/mvn -v"
+
+- name: Delete github maven plugin directory
+  file: path=~/gcloud-maven-plugin state=absent 
+
+- name: Git clone gcloud-maven-plugin
+  git: repo=https://github.com/GoogleCloudPlatform/gcloud-maven-plugin.git dest=~/gcloud-maven-plugin
+
+- name: Build and install maven plugin from head
+  command: "{{maven_home}}/bin/mvn clean install"
+  args:
+        chdir: ~/gcloud-maven-plugin
+
+- name: Delete gcloud installation directory
+  file: path=~/google-cloud-sdk state=absent
+
+- name: Download gcloud sdk
+  get_url:
+        url: https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip
+        dest: /tmp/google-cloud-sdk.zip
+
+- name: Unzip cloud sdk
+  unarchive: src=/tmp/google-cloud-sdk.zip dest=~/ copy=no mode=0755
+
+- name: Install gcloud sdk
+  command: >
+        ./install.sh 
+        --usage-reporting false 
+        --rc-path BOGUS 
+        --command-completion false 
+        --path-update false 
+        --disable-installation-options
+        chdir=~/google-cloud-sdk
+
+- name: gcloud version
+  command: ~/google-cloud-sdk/bin/gcloud --version
+
+- name: Update gcloud components
+  command: ~/google-cloud-sdk/bin/gcloud components update app preview app-engine-java -q
+  args:
+        chdir: ~
+
+#- name: Copy service account key
+#  copy: src={{service_account_key}} dest=~/{{service_account_key}} mode=0600
+
+#- name: Process gcloud_setup script
+#  template: src=gcloud_setup.sh dest=~/gcloud_setup.sh mode=0740
+
+#- name: Provision service account
+#  shell: ./gcloud_setup.sh chdir=~
+#  environment:
+#        CLOUDSDK_PYTHON_SITEPACKAGES: 1
+
+#- name: Set project id, activate service account, and login
+#  command: chdir=~ {{item}}
+#  with_items:
+#j       - ~/google-cloud-sdk/bin/gcloud config set project {{project_id}}
+#       - ~/google-cloud-sdk/bin/gcloud auth activate-service-account {{service_account_email}} 
+#                --key-file ~/{{service_account_key}} --project {{project_id}}
+#    #   - ~/google-cloud-sdk/bin/gcloud auth login {{service_account_email}} --no-launch-browser
+#  environment:
+#        CLOUDSDK_PYTHON_SITEPACKAGES: 1
+
+- name: Unzip maven app
+  unarchive: src=gcloud-maven-plugin-test-app.tar.gz dest=~/ 

--- a/e2e/roles/common/templates/maven_env.sh
+++ b/e2e/roles/common/templates/maven_env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export JAVA_HOME={{java_home}}
+export M2_HOME={{maven_home}}
+PATH=$PATH:$JAVA_HOME/bin:$M2_HOME/bin

--- a/e2e/roles/deployapp/tasks/main.yml
+++ b/e2e/roles/deployapp/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Replace project in pom.xml
+  replace: 
+        dest=~/gcloud-maven-plugin/src/it/gcloud-maven-plugin-test-app/pom.xml 
+        regexp='<gcloud_project>.*?</gcloud_project>'
+
+- name: Remove google_compute keys 
+  file: path={{ item }} state=absent
+  with_items:
+        - ~/.ssh/google_compute_engine
+        - ~/.ssh/google_compute_engine.pub
+
+- name: Generate google_compute_engine key
+  shell: ssh-keygen -f ~/.ssh/google_compute_engine -P ''
+
+- name: Deploy
+  shell: "{{ maven_home }}/bin/mvn gcloud:deploy -Dgcloud.remote=true -Dgcloud.version=e2e chdir=~/gcloud-maven-plugin/src/it/gcloud-maven-plugin-test-app"
+  environment:
+        CLOUDSDK_PYTHON_SITEPACKAGES: 1

--- a/e2e/roles/gcloud/files/gcloud_env.sh
+++ b/e2e/roles/gcloud/files/gcloud_env.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+export CLOUDSDK_PYTHON_SITEPACKAGES=1
+source ~/google-cloud-sdk/completion.bash.inc
+source ~/google-cloud-sdk/path.bash.inc

--- a/e2e/roles/gcloud/tasks/main.yml
+++ b/e2e/roles/gcloud/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+
+- name: Remove VM's default gcloud installation
+  file: path={{ item }} state=absent
+  with_items:
+        - /usr/lib/google-cloud-sdk
+        - /usr/bin/gcloud
+  sudo: yes
+
+- name: Delete previous gcloud sdk installation directory
+  file: path=~/google-cloud-sdk state=absent
+
+- name: Download gcloud sdk
+  get_url:
+        url: https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip
+        dest: /tmp/google-cloud-sdk.zip
+
+- name: Unzip cloud sdk
+  unarchive: src=/tmp/google-cloud-sdk.zip dest=~/ copy=no mode=0755
+
+- name: Install gcloud sdk
+  command: >
+        ./install.sh 
+        --usage-reporting false 
+        --rc-path BOGUS 
+        --command-completion false 
+        --path-update false 
+        --disable-installation-options
+        chdir=~/google-cloud-sdk
+
+- name: Copy gcloud_env.sh environment
+  copy: src=gcloud_env.sh dest=/etc/profile.d/gcloud_env.sh mode=0644
+  sudo: yes
+
+- name: Update gcloud components
+  command: ~/google-cloud-sdk/bin/gcloud components update app preview app-engine-java -q chdir=~

--- a/e2e/roles/maven/tasks/main.yml
+++ b/e2e/roles/maven/tasks/main.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Download maven 3
+  get_url:
+        url: http://mirror.metrocast.net/apache/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.zip
+        dest: /tmp/apache-maven-3.3.3-bin.zip
+  sudo: yes
+
+- name: Create maven dir
+  file: path=/opt/apache-maven-3.3.3 state=directory mode=0755
+  sudo: yes
+
+- name: Unzip maven
+  unarchive: src=/tmp/apache-maven-3.3.3-bin.zip dest=/opt copy=no mode=0755
+  sudo: yes
+
+- name: Install maven_env.sh
+  template: src=maven_env.sh dest=/etc/profile.d/maven_env.sh mode=0644
+  sudo: yes
+
+- name: Delete github maven plugin directory
+  file: path=~/gcloud-maven-plugin state=absent 
+
+- name: Git clone gcloud-maven-plugin
+  git: repo=https://github.com/GoogleCloudPlatform/gcloud-maven-plugin.git dest=~/gcloud-maven-plugin
+
+- name: Build and install maven plugin from head
+  command: "{{maven_home}}/bin/mvn clean install"
+  args:
+        chdir: ~/gcloud-maven-plugin 
+

--- a/e2e/roles/maven/templates/maven_env.sh
+++ b/e2e/roles/maven/templates/maven_env.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+export JAVA_HOME={{java_home}}
+export M2_HOME={{maven_home}}
+PATH=$PATH:$JAVA_HOME/bin:$M2_HOME/bin

--- a/e2e/site.yml
+++ b/e2e/site.yml
@@ -1,0 +1,12 @@
+---
+# Install java7, maven 3, and run e2e. 
+#
+- hosts: compute
+  environment:
+        JAVA_HOME: "{{java_home}}"
+        MAVEN_HOME: "{{maven_home}}"
+  roles:
+    - { role: common, tags: ['common'] }
+    - { role: maven, tags: ['maven'] }
+    - { role: gcloud, tags: ['gcloud'] }
+    - { role: deployapp, tags: ['deployapp'] }


### PR DESCRIPTION
Add ansible playbook that will set up an end to end test. The paybook will do the following:
- install java, maven 3, and other packages onto a predefined Google Cloud Compute instance (see host, create_vm.sh)
- get the latest gcloud-maven-plugin
- get and install the latest gcloud SDK
- deploy a java test application (mvn gcloud:deploy) to App Engine

Note: the creation of Google Compute Engine VM can also be automated in the future. Also, the verification of successful deployment will be implemented later.