### PR TITLE
Fix plugin version in integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <scm>
     <connection>scm:git:https://github.com/ludoch/gcloud-maven-plugin.git</connection>
-    <tag>gcloud-maven-plugin-2.0.9.72.v20150804</tag>
+    <tag>gcloud-maven-plugin-2.0.9.73.v20150804-SNAPSHOT</tag>
   </scm>
   
   <developers>

--- a/src/it/gcloud-maven-plugin-test-app/pom.xml
+++ b/src/it/gcloud-maven-plugin-test-app/pom.xml
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>com.google.appengine</groupId>
         <artifactId>gcloud-maven-plugin</artifactId>
-        <version>2.0.9.72.v20150729-SNAPSHOT</version>
+        <version>2.0.9.73.v20150804-SNAPSHOT</version>
         <configuration>
           <set_default>true</set_default>
           <gcloud_project>${target.cloudproject}</gcloud_project>


### PR DESCRIPTION
The gcloud maven plugin version used in the integration test should match the plugin version in the main project. 