### PR TITLE
Add retries to maven deploy command

### DIFF
--- a/e2e/roles/deployapp/tasks/main.yml
+++ b/e2e/roles/deployapp/tasks/main.yml
@@ -16,3 +16,7 @@
 
 - name: Deploy
   shell: "{{ maven_home }}/bin/mvn gcloud:deploy -Dgcloud.remote=true -Dgcloud.version=e2e chdir=~/gcloud-maven-plugin/src/it/gcloud-maven-plugin-test-app"
+  register: result
+  until: not result|failed
+  retries: 5
+  delay: 15


### PR DESCRIPTION
mvn gcloud:deploy is currently flaky due to server side issues. Retry the task several times.